### PR TITLE
Reposition dropdown after adding item

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1156,6 +1156,7 @@ Selectize.prototype.addItem = function(value) {
 
 			this.updatePlaceholder();
 			this.trigger('item_add', value, $item);
+			this.positionDropdown();
 			this.updateOriginalInput();
 		}
 	});


### PR DESCRIPTION
If you add an item and it causes the `$control` div to change in size, the dropdown will be incorrectly positioned.

The `removeItem` function already makes a call to `positionDropdown`, so this just brings the `addItem` function in line with that.
