### PR TITLE
Added destroy method - closes #35

### DIFF
--- a/examples/destroyable.html
+++ b/examples/destroyable.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]><html class="no-js lt-ie9 lt-ie8 lt-ie7"><![endif]-->
+<!--[if IE 7]><html class="no-js lt-ie9 lt-ie8"><![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9"><![endif]-->
+<!--[if gt IE 8]><!--><html class="no-js"><!--<![endif]-->
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+		<title>Selectize.js Demo</title>
+		<meta name="description" content="">
+		<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
+		<link rel="stylesheet" href="_normalize.css">
+		<link rel="stylesheet" href="_stylesheet.css">
+		<link rel="stylesheet" href="../selectize.css">
+		<!--[if IE 8]><script src="_es5.js"></script><![endif]-->
+		<script src="_jquery.js"></script>
+		<script src="../selectize.js"></script>
+		<script src="_demos.js"></script>
+	</head>
+    <body>
+		<div id="wrapper">
+			<h1>Selectize.js</h1>
+
+			<div class="demo">
+				<h2>&lt;input type="text"&gt;</h2>
+				<div class="control-group">
+					<label for="input-tags">Tags:</label>
+					<input type="text" id="input-tags" class="demo-default" value="awesome,neat">
+					<button type='button' id='destroyer' class='buttons'>Destroy</button>
+				</div>
+				<script>
+				$('#input-tags').selectize({
+					delimiter: ',',
+					persist: false,
+					create: function(input) {
+						return {
+							value: input,
+							text: input
+						}
+					}
+				});
+				$('#destroyer').on('click', function() {
+					$('#input-tags').selectize('destroy');
+				});	
+				</script>
+			</div>
+		</div>
+	</body>
+</html>

--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -4,6 +4,17 @@ $.fn.selectize = function(settings) {
 	var defaults = $.fn.selectize.defaults;
 	var dataAttr = settings.dataAttr || defaults.dataAttr;
 
+	var methods = {
+		destroy: function() {
+			return $(this).each(function() {
+				var $this = $(this);
+				$this.removeClass('selectized');
+				$this.removeData('selectize');
+				$this[0].selectize.destroy();
+			});
+		}
+	};
+
 	/**
 	 * Initializes selectize from a <input type="text"> element.
 	 *
@@ -88,25 +99,32 @@ $.fn.selectize = function(settings) {
 	};
 
 	return this.each(function() {
-		var instance;
-		var $input = $(this);
-		var tag_name = $input[0].tagName.toLowerCase();
-		var settings_element = {
-			'placeholder' : $input.attr('placeholder'),
-			'options'     : {},
-			'optgroups'   : {},
-			'items'       : []
-		};
+		var method = settings;
+		var args = [];
+		if(methods[method]) {
+			method = methods[method];
+			return method.apply(this);
+		}else{
+			var instance;
+			var $input = $(this);
+			var tag_name = $input[0].tagName.toLowerCase();
+			var settings_element = {
+				'placeholder' : $input.attr('placeholder'),
+				'options'     : {},
+				'optgroups'   : {},
+				'items'       : []
+			};
 
-		if (tag_name === 'select') {
-			init_select($input, settings_element);
-		} else {
-			init_textbox($input, settings_element);
+			if (tag_name === 'select') {
+				init_select($input, settings_element);
+			} else {
+				init_textbox($input, settings_element);
+			}
+
+			instance = new Selectize($input, $.extend(true, {}, defaults, settings_element, settings));
+			$input.data('selectize', instance);
+			$input.addClass('selectized');
 		}
-
-		instance = new Selectize($input, $.extend(true, {}, defaults, settings_element, settings));
-		$input.data('selectize', instance);
-		$input.addClass('selectized');
 	});
 };
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -22,6 +22,8 @@ var Selectize = function($input, settings) {
 	this.tagType          = $input[0].tagName.toLowerCase() === 'select' ? TAG_SELECT : TAG_INPUT;
 	this.settings         = settings;
 
+	this.tabIndex         = 0;
+	this.classes          = [];
 	this.highlightedValue = null;
 	this.isOpen           = false;
 	this.isDisabled       = false;
@@ -51,6 +53,7 @@ var Selectize = function($input, settings) {
 	this.items            = [];
 	this.renderCache      = {};
 	this.onSearchChange   = debounce(this.onSearchChange, this.settings.loadThrottle);
+	this.destroy          = this.destroy;
 
 	if ($.isArray(settings.options)) {
 		key = settings.valueField;
@@ -109,14 +112,12 @@ Selectize.prototype.setup = function() {
 	var inputMode;
 	var timeout_blur;
 	var timeout_focus;
-	var tab_index;
-	var classes;
 
-	tab_index         = this.$input.attr('tabindex') || '';
-	classes           = this.$input.attr('class') || '';
-	$wrapper          = $('<div>').addClass(this.settings.theme).addClass(this.settings.wrapperClass).addClass(classes);
+	this.tabIndex     = this.$input.attr('tabindex') || '';
+	this.classes      = this.$input.attr('class') || '';
+	$wrapper          = $('<div>').addClass(this.settings.theme).addClass(this.settings.wrapperClass).addClass(this.classes);
 	$control          = $('<div>').addClass(this.settings.inputClass).addClass('items').toggleClass('has-options', !$.isEmptyObject(this.options)).appendTo($wrapper);
-	$control_input    = $('<input type="text">').appendTo($control).attr('tabindex',tab_index);
+	$control_input    = $('<input type="text">').appendTo($control).attr('tabindex',this.tabIndex);
 	$dropdown         = $('<div>').addClass(this.settings.dropdownClass).hide().appendTo($wrapper);
 	$dropdown_content = $('<div>').addClass(this.settings.dropdownContentClass).appendTo($dropdown);
 
@@ -1667,6 +1668,27 @@ Selectize.prototype.disable = function() {
 Selectize.prototype.enable = function() {
 	this.isDisabled = false;
 	this.unlock();
+};
+
+/**
+ * Destroys Selectize control
+ */
+Selectize.prototype.destroy = function() {
+	$(this.$wrapper).remove();
+	$(this.$control).remove();
+	$(this.$control_input).remove();
+	$(this.$dropdown).remove();
+	$(this.$dropdown_content).remove();
+
+	this.$input.attr('tabindex',this.tabIndex).show().addClass(this.classes);
+	this.isSetup = false;
+
+	$(this.control).off();
+	$(this.dropdown).off();
+	$(this.dropdown).off();
+	$(this.control_input).off();
+
+	this.$input[0].selectize = null;
 };
 
 /**


### PR DESCRIPTION
Basically, there is a `destroy` prototype which is accessible via `$('input')[0].selectize.destroy` and the jQuery plugin has been changed so that if you call `$('input').selectize('destroy')` it'll call it internally.

Hopefully I've covered all basis with this.
