### PR TITLE
Increased z-index

### DIFF
--- a/src/less/selectize.less
+++ b/src/less/selectize.less
@@ -198,7 +198,7 @@
 
 .selectize-dropdown {
 	position: absolute;
-	z-index: 2;
+	z-index: 10;
 	border: @selectize-border;
 	background: @selectize-color-dropdown;
 	margin: -1px 0 0 0;


### PR DESCRIPTION
The `z-index` is too low for something which should be almost highest on page.

When using the default theme with a Bootstrap page, button-groups will appear above the dropdown.
