### PR TITLE
Don't scroll up the dropdown if unnecessary

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -748,7 +748,7 @@ $.extend(Selectize.prototype, {
 			scroll_top    = y;
 			scroll_bottom = y - height_menu + height_item;
 
-			if (y + height_item > height_menu - scroll) {
+			if (y + height_item > height_menu + scroll) {
 				self.$dropdown_content.stop().animate({scrollTop: scroll_bottom}, animate ? self.settings.scrollDuration : 0);
 			} else if (y < scroll) {
 				self.$dropdown_content.stop().animate({scrollTop: scroll_top}, animate ? self.settings.scrollDuration : 0);

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1378,10 +1378,10 @@ $.extend(Selectize.prototype, {
 		var isFull   = self.isFull();
 		var isLocked = self.isLocked;
 
-		this.$wrapper
+		self.$wrapper
 			.toggleClass('rtl', self.rtl);
 
-		this.$control
+		self.$control
 			.toggleClass('focus', self.isFocused)
 			.toggleClass('disabled', self.isDisabled)
 			.toggleClass('required', self.isRequired)
@@ -1393,7 +1393,7 @@ $.extend(Selectize.prototype, {
 			.toggleClass('has-options', !$.isEmptyObject(self.options))
 			.toggleClass('has-items', self.items.length > 0);
 
-		this.$control_input.data('grow', !isFull && !isLocked);
+		self.$control_input.data('grow', !isFull && !isLocked);
 	},
 
 	/**
@@ -1461,7 +1461,7 @@ $.extend(Selectize.prototype, {
 		self.$dropdown.css({visibility: 'hidden', display: 'block'});
 		self.positionDropdown();
 		self.$dropdown.css({visibility: 'visible'});
-		self.trigger('dropdown_open', this.$dropdown);
+		self.trigger('dropdown_open', self.$dropdown);
 	},
 
 	/**
@@ -1471,7 +1471,7 @@ $.extend(Selectize.prototype, {
 		var self = this;
 		var trigger = self.isOpen;
 
-		if (self.settings.mode === 'single' && this.items.length) {
+		if (self.settings.mode === 'single' && self.items.length) {
 			self.hideInput();
 		}
 


### PR DESCRIPTION
Try this: scroll down in the dropdown then press UP repeatedly.

Before fix : dropdown scrolls up even if unnecessary, e.g. the new active option is entirely visible in the dropdown.
After : dropdown scrolls up only if the target option is out of the visible part of the dropdown.
