### PR TITLE
Allow Developers to Disable Selectize Autogrow

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,6 +23,12 @@ $(function() {
 		<th valign="top" width="60px" align="left">Default</th>
 	</tr>
 	<tr>
+		<td valign="top"><code>autogrow</code></td>
+		<td valign="top">Whether or not autogrow is enabled for selectize boxes. Disable this if autogrow gives you JS performance issues.</td>
+		<td valign="top"><code>boolean</code></td>
+		<td valign="top"><code>true</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>delimiter</code></td>
 		<td valign="top">The string to separate items by. This option is only used when Selectize is instantiated from a &lt;input type="text"&gt; element.</td>
 		<td valign="top"><code>string</code></td>

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -142,7 +142,7 @@ $.extend(Selectize.prototype, {
 		$dropdown.on('mouseenter', '[data-selectable]', function() { return self.onOptionHover.apply(self, arguments); });
 		$dropdown.on('mousedown', '[data-selectable]', function() { return self.onOptionSelect.apply(self, arguments); });
 		watchChildEvent($control, 'mousedown', '*:not(input)', function() { return self.onItemSelect.apply(self, arguments); });
-		autoGrow($control_input);
+		if (typeof settings.autogrow === "undefined" || settings.autogrow) autoGrow($control_input);
 
 		$control.on({
 			mousedown : function() { return self.onMouseDown.apply(self, arguments); },


### PR DESCRIPTION
There are times autogrow isn't wanted and times the current autogrow implementation in Selectize.js causes serious performance issues. We had a page that was taking 40 seconds to Selectize around 1700 select boxes, and traced the hotspot back to the autogrow code in Selectize. With autogrow disabled, we were able to Selectize all of those boxes in around 2 seconds.
