### PR TITLE
don't preload results in setup() when preload option is set to focus

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -230,7 +230,7 @@ $.extend(Selectize.prototype, {
 		self.trigger('initialize');
 
 		// preload options
-		if (settings.preload) {
+		if (settings.preload === true) {
 			self.onSearchChange('');
 		}
 	},


### PR DESCRIPTION
When I tried to use `preload: "focus"` in my settings results got preloaded once `selectize` got initialized.
Here is a fix for that.
