### PR TITLE
Add composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "2amigos/selectize.js",
+    "name": "brianreavis/selectize.js",
     "description": "Selectize is the hybrid of a textbox and <select> box. It's jQuery based and it has autocomplete and native-feeling keyboard navigation; useful for tagging, contact lists, etc.",
     "keywords": ["plugin", "jquery", "hybrid", "autocomplete"],
     "homepage": "http://brianreavis.github.io/selectize.js/",        

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "2amigos/selectize.js",
+    "description": "Selectize is the hybrid of a textbox and <select> box. It's jQuery based and it has autocomplete and native-feeling keyboard navigation; useful for tagging, contact lists, etc.",
+    "keywords": ["plugin", "jquery", "hybrid", "autocomplete"],
+    "homepage": "http://brianreavis.github.io/selectize.js/",        
+    "authors": [
+        {
+            "name": "Brian Reavis",            
+            "homepage": "http://brianreavis.github.io/selectize.js/"
+        }
+    ]    
+}


### PR DESCRIPTION
It would be great to have composer.json and official packagist package (twitter and fontawesome do that already) in the main repository so selectize would be installable as composer (current PHP package manager) package.

Edit: At the moment, we have our own maintained package repository: https://packagist.org/packages/brianreavis/selectize.js as we need your library as a package. Will be removed whenever you consider adding composer.json file. 
