### PR TITLE
blurOnEmptyReturn-option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,6 +42,14 @@ $(function() {
 		<td valign="top"><code>false</code></td>
 	</tr>
 	<tr>
+	<tr>
+		<td valign="top"><code>blurOnEmptyReturn</code></td>
+		<td valign="top">
+			If true, when user presses enter and input is empty dropdown is closed. Default behavior is to select active item from dropdown.
+		<td valign="top"><code>boolean</code></td>
+		<td valign="top"><code>false</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>highlight</code></td>
 		<td valign="top">Toggles match highlighting within the dropdown menu.</td>
 		<td valign="top"><code>boolean</code></td>

--- a/examples/blurOnEmptyReturn.html
+++ b/examples/blurOnEmptyReturn.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]><html class="no-js lt-ie9 lt-ie8 lt-ie7"><![endif]-->
+<!--[if IE 7]><html class="no-js lt-ie9 lt-ie8"><![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9"><![endif]-->
+<!--[if gt IE 8]><!--><html class="no-js"><!--<![endif]-->
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+		<title>Selectize.js Demo</title>
+		<meta name="description" content="">
+		<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
+		<link rel="stylesheet" href="css/normalize.css">
+		<link rel="stylesheet" href="css/stylesheet.css">
+		<!--[if IE 8]><script src="js/es5.js"></script><![endif]-->
+		<script src="js/jquery.js"></script>
+		<script src="../dist/js/standalone/selectize.js"></script>
+		<script src="js/index.js"></script>
+	</head>
+    <body>
+		<div id="wrapper">
+			<h1>Selectize.js</h1>
+
+			<div class="demo">
+				<h2>&lt;input type="text"&gt;</h2>
+				<div class="control-group">
+					<label for="input-tags">Tags:</label>
+					<select id="input-tags" class="demo-default" placeholder="Select a person...">
+						<option value="">Select a person...</option>
+						<option value="4">Thomas Edison</option>
+						<option value="1">Nikola</option>
+						<option value="3">Nikola Tesla</option>
+						<option value="5">Arnold Schwarzenegger</option>
+					</select>
+				</div>
+				<script>
+				$('#input-tags').selectize({
+					maxItems: 3,
+					blurOnEmptyReturn: true,
+				});
+				</script>
+			</div>
+
+			<div class="demo">
+				<h2>&lt;select&gt;</h2>
+				<div class="control-group">
+					<label for="select-beast">Beast:</label>
+					<select id="select-beast" class="demo-default" placeholder="Select a person...">
+						<option value="">Select a person...</option>
+						<option value="4">Thomas Edison</option>
+						<option value="1">Nikola</option>
+						<option value="3">Nikola Tesla</option>
+						<option value="5">Arnold Schwarzenegger</option>
+					</select>
+				</div>
+				<script>
+				$('#select-beast').selectize({
+					create: true,
+					createOnBlur: true,
+					blurOnEmptyReturn: true,
+				});
+				</script>
+			</div>
+		</div>
+	</body>
+</html>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -6,6 +6,7 @@ Selectize.defaults = {
 	diacritics: true,
 	create: false,
 	createOnBlur: false,
+	blurOnEmptyReturn: false,
 	highlight: true,
 	openOnFocus: true,
 	maxOptions: 1000,

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -415,7 +415,7 @@ $.extend(Selectize.prototype, {
 				e.preventDefault();
 				return;
 			case KEY_RETURN:
-				if (self.settings.blurOnEmptyReturn && $.trim(self.$control_input.val()).length) {
+				if (self.settings.blurOnEmptyReturn && $.trim(self.$control_input.val() || '').length === 0) {
 					self.blur();
 				} else if (self.isOpen && self.$activeOption) {
 					self.onOptionSelect({currentTarget: self.$activeOption});

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -415,7 +415,9 @@ $.extend(Selectize.prototype, {
 				e.preventDefault();
 				return;
 			case KEY_RETURN:
-				if (self.isOpen && self.$activeOption) {
+				if (self.settings.blurOnEmptyReturn && $.trim(self.$control_input.val()).length) {
+					self.blur();
+				} else if (self.isOpen && self.$activeOption) {
 					self.onOptionSelect({currentTarget: self.$activeOption});
 				}
 				e.preventDefault();


### PR DESCRIPTION
Currently when user presses enter key if there is active selection on drop down that option is selected. And some option is always active if there are any unselected options.

Sometimes that is not preferred action, e.g. when we have single-select input where empty value is valid input. Currently, user will clear input by pressing backspace and then tries to exit the field by pressing return. But instead of leaving input empty some option will be selected.

With this option no option will be selected if input is empty and user presses enter.
