### PR TITLE
Added a clearCache method to clear the render cache

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -195,6 +195,10 @@ var selectize = $select[0].selectize;
 		<td valign="top"><code>isFull()</code></td>
 		<td valign="top">Returns whether or not the user can select more items.</td>
 	</tr>
+	<tr>
+		<td valign="top"><code>clearCache(template)</code></td>
+		<td valign="top">Clears the render cache. Takes an optional template argument (e.g. "option", "item") to clear only that cache.</td>
+	</tr>
 </table>
 
 ### Related Objects

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1830,6 +1830,23 @@ $.extend(Selectize.prototype, {
 		}
 
 		return html;
+	}, 
+
+	/**
+	 * Clears the render cache for a template. If
+	 * no template is given, clears all render
+	 * caches.
+	 *
+	 * @param {string} templateName
+	 */
+	clearCache: function(templateName) {
+		var self = this;
+		if (typeof templateName === 'undefined') {
+			self.renderCache = {};
+		} else {
+			delete self.renderCache[templateName];
+		}
 	}
+
 
 });

--- a/test/api.js
+++ b/test/api.js
@@ -567,6 +567,41 @@
 			});
 		});
 
+		describe('clearCache()', function() {
+			var test;
+
+			before(function() {
+				test = setup_test('<select multiple>', {
+					valueField: 'value',
+					labelField: 'value',
+					options: [
+						{value: 0},
+						{value: 1},
+						{value: 2},
+						{value: 3},
+					],
+					items: ['1','2','3']
+				});
+				test.selectize.advanceSelection(1);
+				test.selectize.refreshOptions(true);
+				test.selectize.refreshItems();
+			});
+			it('should clear the whole renderCache', function () {
+				expect($.isEmptyObject(test.selectize.renderCache)).to.be.equal(false);
+				test.selectize.clearCache();
+				expect($.isEmptyObject(test.selectize.renderCache)).to.be.equal(true);
+			});
+			it('should allow clearing just one template type from the renderCache', function () {
+				test.selectize.render('item', test.selectize.options[0]);
+				test.selectize.refreshOptions();
+				expect($.isEmptyObject(test.selectize.renderCache['option'])).to.be.equal(false);
+				expect($.isEmptyObject(test.selectize.renderCache['item'])).to.be.equal(false);
+				test.selectize.clearCache('option');
+				expect($.isEmptyObject(test.selectize.renderCache['option'])).to.be.equal(true);
+				expect($.isEmptyObject(test.selectize.renderCache['item'])).to.be.equal(false);
+			});
+		});
+
 	});
 
 })();


### PR DESCRIPTION
I ran into an issue while using selectize where I wanted to render options based on the value set in a previous selectize (e.g. when a school course is chosen, show the times for that course). Calling refreshOptions wouldn't re-render the options because they were cached. I had to clear the renderCache manually, then the render function would get called next time the list was opened.

If this is expected behavior, I think providing a documented method to do so might be clearer. If this doesn't fit in with the intentions of selectize, feel free to close the PR or post any changes you'd like me to make.
