### PR TITLE
Reset renderCache in clear() function

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1535,6 +1535,7 @@ $.extend(Selectize.prototype, {
 		if (!self.items.length) return;
 		self.$control.children(':not(input)').remove();
 		self.items = [];
+		self.renderCache = {}; // remove rendered cache
 		self.setCaret(0);
 		self.updatePlaceholder();
 		self.updateOriginalInput();


### PR DESCRIPTION
Reset renderCache in clear() function. It makes options list fresh in case the list got new items when calling the load()function.
