### PR TITLE
issue removeItem() before addItem() iff maxItems=1

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1257,7 +1257,13 @@ $.extend(Selectize.prototype, {
 			}
 
 			if (!self.options.hasOwnProperty(value)) return;
-			if (inputMode === 'single') self.clear();
+			if (inputMode === 'single') {
+				while (self.items.length) {
+					self.removeItem(self.items.pop());
+				}
+				self.$control.children(':not(input)').remove();
+				self.setCaret(0);
+			}
 			if (inputMode === 'multi' && self.isFull()) return;
 
 			$item = $(self.render('item', self.options[value]));


### PR DESCRIPTION
Thanks for selectize!

I noticed that when `maxItems=1` only `item_add` events are emitted, which doesn't play well with other objects trying to monitor selectize.  This change causes any selected items to get removed (with all that entails) in `addItem()` before new items are selected.

I used a loop to handle the (unlikely) case in which multiple items are currently selected and the settings are changed programmatically.

Tests pass.
