### PR TITLE
Add selectOnTab config option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,6 +115,12 @@ $(function() {
 		<td valign="top"><code>false</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>selectOnTab</code></td>
+		<td valign="top">If true, the tab key will choose the currently selected item.</td>
+		<td valign="top"><code>boolean</code></td>
+		<td valign="top"><code>false</code></td>
+	</tr>
+	<tr>
 		<th valign="top" colspan="4" align="left"><a href="#data_searching" name="data_searching">Data / Searching</a></th>
 	</tr>
 	<tr>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -12,6 +12,7 @@ Selectize.defaults = {
 	maxItems: null,
 	hideSelected: null,
 	addPrecedence: false,
+	selectOnTab: false,
 	preload: false,
 
 	scrollDuration: 60,

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -431,7 +431,7 @@ $.extend(Selectize.prototype, {
 				self.advanceSelection(1, e);
 				return;
 			case KEY_TAB:
-				if (self.isOpen && self.$activeOption) {
+				if (self.settings.selectOnTab && self.isOpen && self.$activeOption) {
 					self.onOptionSelect({currentTarget: self.$activeOption});
 				}
 				if (self.settings.create && self.createItem()) {


### PR DESCRIPTION
Adds a new config option called "selectOnTab" to make the functionality added in #258 optional since it is undesirable behavior in the event that there are many, potentially not required, Selectize controls in a single form (as just tabbing through them will cause the first option to be selected in each). 

I ended up defaulting it to false as this was the "default" behavior prior to 0.9.0.
