### PR TITLE
Allow preventing onSearchChange debounce by specifying null for loadThrottle

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,7 +92,7 @@ $(function() {
 	</tr>
 	<tr>
 		<td valign="top"><code>loadThrottle</code></td>
-		<td valign="top">The number of milliseconds to wait before requesting options from the server.</td>
+		<td valign="top">The number of milliseconds to wait before requesting options from the server or null. If null, throttling is disabled.</td>
 		<td valign="top"><code>int</code></td>
 		<td valign="top"><code>300</code></td>
 	</tr>

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -44,7 +44,7 @@ var Selectize = function($input, settings) {
 		userOptions      : {},
 		items            : [],
 		renderCache      : {},
-		onSearchChange   : debounce(self.onSearchChange, settings.loadThrottle)
+		onSearchChange   : settings.loadThrottle === null ? self.onSearchChange : debounce(self.onSearchChange, settings.loadThrottle)
 	});
 
 	// search system


### PR DESCRIPTION
In unit testing our component that utilizes Selectize, I found that removing the debounce made things simpler to test since it removed the need to utilize timeouts and such to get everything to flow correctly. I'm not positive this is the best (or remotely ideal) way to handle this but it has been effective so far.
