### PR TITLE
Add onOptionSelect event

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -280,7 +280,8 @@ $.extend(Selectize.prototype, {
 			'option_clear'   : 'onOptionClear',
 			'dropdown_open'  : 'onDropdownOpen',
 			'dropdown_close' : 'onDropdownClose',
-			'type'           : 'onType'
+			'type'           : 'onType',
+			'option_select'  : 'onOptionSelect'
 		};
 
 		for (key in callbacks) {
@@ -571,6 +572,7 @@ $.extend(Selectize.prototype, {
 		} else {
 			value = $target.attr('data-value');
 			if (value) {
+				self.trigger('option_select', value);
 				self.lastQuery = null;
 				self.setTextboxValue('');
 				self.addItem(value);


### PR DESCRIPTION
onOptionSelect now triggers an option_select event when there is a value
set on the option and passes that value to the event handler. The event
handler can be specified by setting the onOptionSelect property when
passing options to selectize.

We needed this for something internal and rather than end up with disparity between our versions and the library I thought I'd see if you thought it would be useful to other people. At the moment it only sends the event if there is a value to pass to it but you may feel it makes more sense to send the event regardless.
