### PR TITLE
Reflect the values of autocorrect and autocapitalize attributes 

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -133,6 +133,14 @@ $.extend(Selectize.prototype, {
 			$control_input.attr('placeholder', settings.placeholder);
 		}
 
+		if (self.$input.attr('autocorrect')) {
+			$control_input.attr('autocorrect', self.$input.attr('autocorrect'));
+		}
+
+		if (self.$input.attr('autocapitalize')) {
+			$control_input.attr('autocapitalize', self.$input.attr('autocapitalize'));
+		}
+
 		self.$wrapper          = $wrapper;
 		self.$control          = $control;
 		self.$control_input    = $control_input;

--- a/test/setup.js
+++ b/test/setup.js
@@ -14,7 +14,7 @@
 		});
 
 		describe('<input type="text">', function() {
-			it('complete without exceptions', function() {
+			it('should complete without exceptions', function() {
 				var test = setup_test('<input type="text">', {});
 			});
 			describe('getValue()', function() {
@@ -26,9 +26,21 @@
 					var test = setup_test('<input type="text" value="">', {delimiter: ','});
 					expect(test.selectize.getValue()).to.be.equal('');
 				});
-				it('should proper value when not empty', function() {
+				it('should return proper value when not empty', function() {
 					var test = setup_test('<input type="text" value="a,b">', {delimiter: ','});
 					expect(test.selectize.getValue()).to.be.equal('a,b');
+				});
+			});
+			describe('<input type="text" attributes>', function() {
+				it('should propagate original input attributes to the generated input', function() {
+					var test = setup_test('<input type="text" autocorrect="off" autocapitalize="none">', {});
+					expect(test.selectize.$control_input.attr('autocorrect')).to.be.equal('off');
+					expect(test.selectize.$control_input.attr('autocapitalize')).to.be.equal('none');
+				});
+				it('should not add attributes if not present in the original', function() {
+					var test = setup_test('<input type="text">', {});
+					expect(test.selectize.$control_input.attr('autocorrect')).to.be.equal(undefined);
+					expect(test.selectize.$control_input.attr('autocapitalize')).to.be.equal(undefined);
 				});
 			});
 		});


### PR DESCRIPTION
**Reflect the values of autocorrect and autocapitalize attributes in the control input, if they were set on the original input. With tests.**

iOS [supports two HTML attributes](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html) on `<input>` elements called “autocorrect” and “autocapitalize”.

`<input type="text" name="tags" autocomplete="off" autocorrect="off" autocapitalize="none">`

They are particularly useful in stopping the OS from interfering with tagging interfaces, where many users prefer to keep all their tags in lowercase. At the moment, iOS will engage the Shift key on the virtual keyboard before a user starts typing into a selectized `<input>`, capitalizing the first character typed.

This pull request simply checks for the presence of these attributes on the original `<input>` element that selectize is called on, and attaches them to the generated control `<input>` with the same values. I added a couple of tests for this too.

![titlecase_tags](https://cloud.githubusercontent.com/assets/4503044/2691329/30fa6662-c37c-11e3-8416-cf5c2f7f998e.png)
