### PR TITLE
Prevent Selectize from causing unwanted scrolling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
 	"name": "selectize",
 	"keywords": ["select", "ui", "form", "input", "control", "autocomplete", "tagging", "tag"],
 	"description": "Selectize is a jQuery-based custom <select> UI control. Useful for tagging, contact lists, country selectors, etc.",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"license": "Apache License, Version 2.0",
 	"readmeFilename": "README.md",
 	"repository": {

--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -1836,7 +1836,7 @@
 			var self = this;
 	
 			self.setTextboxValue('');
-			self.$control_input.css({opacity: 0, position: 'absolute', left: self.rtl ? 10000 : -10000});
+			self.$control_input.css({opacity: 0});
 			self.isInputHidden = true;
 		},
 	

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -788,7 +788,7 @@ $.extend(Selectize.prototype, {
 		var self = this;
 
 		self.setTextboxValue('');
-		self.$control_input.css({opacity: 0, position: 'absolute', left: self.rtl ? 10000 : -10000});
+		self.$control_input.css({opacity: 0, position: 'absolute'});
 		self.isInputHidden = true;
 	},
 


### PR DESCRIPTION
In Chromium, if selectize is inside of a scrollable area, moving the menu 1000px can cause the user's view to scroll 1000 pixels.

Here's a plunkr demonstrating the patch:
http://plnkr.co/edit/y6MVSO?p=preview
