### PR TITLE
Fix issue #343

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -236,7 +236,8 @@ $.extend(Selectize.prototype, {
 		}
 
 		self.on('change', this.onChange);
-		self.trigger('initialize');
+		// self.trigger('initialize');
+		self.$input.trigger('initialize');
 
 		// preload options
 		if (settings.preload === true) {


### PR DESCRIPTION
It's impossible to capture the _initialize_ event using `selectize.on('initialize', handler);` because `selectize` object is returned just after the event is triggered. Using `$input` object to trigger the  initialize event can avoid this and captures the event. For example:

```
var $select = $(selector).on('initialize', function() {
  console.log('init');
}).selectize(options);
```
