### PR TITLE
Added fix to not add "required" attr unless field is actually required.

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1439,7 +1439,9 @@ $.extend(Selectize.prototype, {
 		var self = this;
 		var invalid = self.isRequired && !self.items.length;
 		if (!invalid) self.isInvalid = false;
-		self.$control_input.prop('required', invalid);
+		if (self.isRequired) {
+			self.$control_input.prop('required', invalid);
+		};
 		self.refreshClasses();
 	},
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -218,6 +218,30 @@
 			}
 		});
 
+		describe('<select> (not required)', function(){
+			var $form, $button, test;
+
+			beforeEach(function() {
+				test = setup_test('<select>' +
+					'<option value="">Select an option...</option>' +
+					'<option value="a">A</option>' +
+				'</select>', {});
+				$form = test.$select.parents('form');
+				$button = $('<button type="submit">').appendTo($form);
+			});
+			afterEach(function() {
+				$form.off('.test_required');
+				$button.remove();
+			});
+
+			it('should have isRequired property set to false', function() {
+				expect(test.selectize.isRequired).to.be.equal(false);
+			});
+			it('should not have the required class', function() {
+				expect(test.selectize.$control.hasClass('required')).to.be.equal(false);
+			});
+		});
+
 	});
 
 })();


### PR DESCRIPTION
According to the HTML5 spec, the `required` attribute is a boolean attribute. Just having it present (even if it's value is "false") makes the element required. Most browsers will still work with the attribute set to false, but I've made a very small change to not add the attr at all if the original select does not have the `required` attribute. This should hopefully future-proof it in case browser's change their mind. I've only noticed IE8 marking the field as invalid even with `required="false"`.

I've added some basic tests along with it, but if you need me to make them more robust, let me know.
