### PR TITLE
"remove_button" css fix for bootstrap 3

### DIFF
--- a/dist/css/selectize.bootstrap3.css
+++ b/dist/css/selectize.bootstrap3.css
@@ -68,7 +68,7 @@
 .selectize-dropdown.plugin-optgroup_columns .optgroup-header {
   border-top: 0 none;
 }
-.selectize-control.plugin-remove_button [data-value] {
+.selectize-control.multi.plugin-remove_button [data-value] {
   position: relative;
   padding-right: 24px !important;
 }


### PR DESCRIPTION
When we use "remove_button" plugin our input position of single select elements moves to right.
