### PR TITLE
Create proxy method to close empty dropdown

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1541,7 +1541,7 @@ $.extend(Selectize.prototype, {
 	 * Proxy method to close the dropdown when it has no option available.
 	 * This proxy exists only to facilitate a plugin override for this specific context
 	 */
-	closeEmptyDropdown: function {
+	closeEmptyDropdown: function() {
 		this.close();
 	},
 	

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1058,7 +1058,7 @@ $.extend(Selectize.prototype, {
 			if (triggerDropdown && !self.isOpen) { self.open(); }
 		} else {
 			self.setActiveOption(null);
-			if (triggerDropdown && self.isOpen) { self.close(); }
+			if (triggerDropdown && self.isOpen) { self.closeEmptyDropdown(); }
 		}
 	},
 
@@ -1537,6 +1537,14 @@ $.extend(Selectize.prototype, {
 		self.trigger('dropdown_open', self.$dropdown);
 	},
 
+	/**
+	 * Proxy method to close the dropdown when it has no option available.
+	 * This proxy exists only to facilitate a plugin override for this specific context
+	 */
+	closeEmptyDropdown: function {
+		this.close();
+	},
+	
 	/**
 	 * Closes the autocomplete dropdown menu.
 	 */


### PR DESCRIPTION
Proxy method to facilitate plugin overrides

We need to prevent selectize from closing the dropdown when first triggered even if there's no options available.

We need to show the dropdown to display a custom message to the user to inform him that there's no data available with his current filters.  He also needs to see the custom "Add" button that we've injected with a plugin in the dropdown.

I figured that a proxy method that could be overriden by a plugin would be better that overriding the whole "refreshOptions" method.

If there's a better way to achieve this, i'm open to suggestions
