### PR TITLE
Add clearInput flag to clearOptions()

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1186,7 +1186,7 @@ $.extend(Selectize.prototype, {
 	/**
 	 * Clears all options.
 	 */
-	clearOptions: function() {
+	clearOptions: function(clearInput) {
 		var self = this;
 
 		self.loadedSearches = {};
@@ -1195,7 +1195,7 @@ $.extend(Selectize.prototype, {
 		self.options = self.sifter.items = {};
 		self.lastQuery = null;
 		self.trigger('option_clear');
-		self.clear();
+		if (clearInput === true || typeof clearInput === 'undefined') self.clear();
 	},
 
 	/**


### PR DESCRIPTION
Only clear user input when clearInput is true or undefined.

The undefined check is to make sure this change doesn't break any existing code. 
