### PR TITLE
Default value for create option is false

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,7 +37,7 @@ $(function() {
 	<tr>
 		<td valign="top"><code>create</code></td>
 		<td valign="top">
-			Allows the user to create a new items that aren't in the list of options. This option can be any of the following: "true" (default behavior), "false" (disabled), or a function that accepts two arguments: "input" and "callback". The callback should be invoked with the final data for the option.</td>
+			Allows the user to create a new items that aren't in the list of options. This option can be any of the following: "true" (enabled), "false" (disabled), or a function that accepts two arguments: "input" and "callback". The callback should be invoked with the final data for the option.</td>
 		<td valign="top"><code>mixed</code></td>
 		<td valign="top"><code>false</code></td>
 	</tr>


### PR DESCRIPTION
The mention that `true` is the _default behavior_ is really confusing and I'm not even sure what it means. The default value of the option is `false`.
