### PR TITLE
renamed the undefined plugins variable to selector_plugins

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,7 +89,7 @@ module.exports = function(grunt) {
 		if (!selector_plugins) return;
 
 		if (selector_plugins.indexOf(',') !== -1) {
-			selector_plugins = '{' + plugins.split(/\s*,\s*/).join(',') + '}';
+			selector_plugins = '{' + selector_plugins.split(/\s*,\s*/).join(',') + '}';
 		}
 
 		// javascript


### PR DESCRIPTION
While creating a build by specifying the plugins option as comma separated value it throws the following error:

```
Loading "Gruntfile.js" tasks...ERROR
>> ReferenceError: plugins is not defined

Running "clean:pre" (clean) task
Verifying property clean.pre exists in config...ERROR
>> Unable to process task.
Warning: Required config property "clean.pre" missing. Use --force to continue.

Aborted due to warnings.
```

I looked into the Gruntfile.js & found out you forgot to rename the variable in [one of your commits](https://github.com/brianreavis/selectize.js/commit/3a76dcce1ae1438496d12130e86e4616b0089616)

@brianreavis 
