### PR TITLE
Declared canCreate() function regardless of `create` option.

### DIFF
--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -2851,6 +2851,7 @@
 				// add event listener
 				this.$control.on('click', '.' + options.className, function(e) {
 					e.preventDefault();
+                                        e.stopPropagation();
 					if (self.isLocked) return;
 	
 					var $item = $(e.currentTarget).parent();

--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -528,15 +528,13 @@
 			self.settings.hideSelected = self.settings.mode === 'multi';
 		}
 	
-		if (self.settings.create) {
-			self.canCreate = function(input) {
-				var filter = self.settings.createFilter;
-				return input.length
-					&& (typeof filter !== 'function' || filter.apply(self, [input]))
-					&& (typeof filter !== 'string' || new RegExp(filter).test(input))
-					&& (!(filter instanceof RegExp) || filter.test(input));
-			};
-		}
+		self.canCreate = function(input) {
+                    var filter = self.settings.createFilter;
+                    return input.length
+                        && (typeof filter !== 'function' || filter.apply(self, [input]))
+                        && (typeof filter !== 'string' || new RegExp(filter).test(input))
+                        && (!(filter instanceof RegExp) || filter.test(input));
+                };
 	
 		self.initializePlugins(self.settings.plugins);
 		self.setupCallbacks();

--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -508,7 +508,8 @@
 			userOptions      : {},
 			items            : [],
 			renderCache      : {},
-			onSearchChange   : settings.loadThrottle === null ? self.onSearchChange : debounce(self.onSearchChange, settings.loadThrottle)
+			onSearchChange   : settings.loadThrottle === null ? self.onSearchChange : debounce(self.onSearchChange, settings.loadThrottle),
+                        enableDuplicate  : false
 		});
 	
 		// search system
@@ -1772,7 +1773,7 @@
 				var i, active, value_next, wasFull;
 				value = hash_key(value);
 	
-				if (self.items.indexOf(value) !== -1) {
+				if (!self.settings.enableDuplicate && self.items.indexOf(value) !== -1) {
 					if (inputMode === 'single') self.close();
 					return;
 				}

--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -1094,7 +1094,8 @@
 			userOptions      : {},
 			items            : [],
 			renderCache      : {},
-			onSearchChange   : settings.loadThrottle === null ? self.onSearchChange : debounce(self.onSearchChange, settings.loadThrottle)
+			onSearchChange   : settings.loadThrottle === null ? self.onSearchChange : debounce(self.onSearchChange, settings.loadThrottle),
+                        enableDuplicate  : false
 		});
 	
 		// search system
@@ -2358,7 +2359,7 @@
 				var i, active, value_next, wasFull;
 				value = hash_key(value);
 	
-				if (self.items.indexOf(value) !== -1) {
+				if (!self.settings.enableDuplicate && self.items.indexOf(value) !== -1) {
 					if (inputMode === 'single') self.close();
 					return;
 				}

--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -1114,15 +1114,13 @@
 			self.settings.hideSelected = self.settings.mode === 'multi';
 		}
 	
-		if (self.settings.create) {
-			self.canCreate = function(input) {
-				var filter = self.settings.createFilter;
-				return input.length
-					&& (typeof filter !== 'function' || filter.apply(self, [input]))
-					&& (typeof filter !== 'string' || new RegExp(filter).test(input))
-					&& (!(filter instanceof RegExp) || filter.test(input));
-			};
-		}
+		self.canCreate = function(input) {
+                    var filter = self.settings.createFilter;
+                    return input.length
+                        && (typeof filter !== 'function' || filter.apply(self, [input]))
+                        && (typeof filter !== 'string' || new RegExp(filter).test(input))
+                        && (!(filter instanceof RegExp) || filter.test(input));
+                };
 	
 		self.initializePlugins(self.settings.plugins);
 		self.setupCallbacks();

--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -3437,6 +3437,7 @@
 				// add event listener
 				this.$control.on('click', '.' + options.className, function(e) {
 					e.preventDefault();
+                                        e.stopPropagation();
 					if (self.isLocked) return;
 	
 					var $item = $(e.currentTarget).parent();

--- a/src/plugins/remove_button/plugin.js
+++ b/src/plugins/remove_button/plugin.js
@@ -55,6 +55,7 @@ Selectize.define('remove_button', function(options) {
 			// add event listener
 			this.$control.on('click', '.' + options.className, function(e) {
 				e.preventDefault();
+                                e.stopPropagation();
 				if (self.isLocked) return;
 
 				var $item = $(e.currentTarget).parent();

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -45,7 +45,8 @@ var Selectize = function($input, settings) {
 		userOptions      : {},
 		items            : [],
 		renderCache      : {},
-		onSearchChange   : settings.loadThrottle === null ? self.onSearchChange : debounce(self.onSearchChange, settings.loadThrottle)
+		onSearchChange   : settings.loadThrottle === null ? self.onSearchChange : debounce(self.onSearchChange, settings.loadThrottle),
+                enableDuplicate  : false
 	});
 
 	// search system
@@ -1309,7 +1310,7 @@ $.extend(Selectize.prototype, {
 			var i, active, value_next, wasFull;
 			value = hash_key(value);
 
-			if (self.items.indexOf(value) !== -1) {
+			if (!self.settings.enableDuplicate && self.items.indexOf(value) !== -1) {
 				if (inputMode === 'single') self.close();
 				return;
 			}

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -65,15 +65,13 @@ var Selectize = function($input, settings) {
 		self.settings.hideSelected = self.settings.mode === 'multi';
 	}
 
-	if (self.settings.create) {
-		self.canCreate = function(input) {
-			var filter = self.settings.createFilter;
-			return input.length
-				&& (typeof filter !== 'function' || filter.apply(self, [input]))
-				&& (typeof filter !== 'string' || new RegExp(filter).test(input))
-				&& (!(filter instanceof RegExp) || filter.test(input));
-		};
-	}
+	self.canCreate = function(input) {
+            var filter = self.settings.createFilter;
+            return input.length
+                && (typeof filter !== 'function' || filter.apply(self, [input]))
+                && (typeof filter !== 'string' || new RegExp(filter).test(input))
+                && (!(filter instanceof RegExp) || filter.test(input));
+        };
 
 	self.initializePlugins(self.settings.plugins);
 	self.setupCallbacks();


### PR DESCRIPTION
Allow to change `create` option after plugin initialization without `canCreate()`  error.
Related to https://github.com/brianreavis/selectize.js/issues/532.
