### PR TITLE
Remove duplicate and not valid property '*display' in selectize.less

### DIFF
--- a/src/less/selectize.less
+++ b/src/less/selectize.less
@@ -141,7 +141,6 @@
 		display: -moz-inline-stack;
 		display: inline-block;
 		zoom: 1;
-		*display: inline;
 	}
 	.selectize-control.multi & > div {
 		cursor: pointer;


### PR DESCRIPTION
class `.selectize-input > *` already have property `display: inline-block;`
I think duplicating this property is a mistake.

Moreover, the writing of "*display" - is wrong.
