### PR TITLE
updateOption: invalidate last query

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1182,6 +1182,9 @@ $.extend(Selectize.prototype, {
 			$item.replaceWith($item_new);
 		}
 
+		//invalidate last query because we might have updated the sortField
+		self.lastQuery = null;
+
 		// update dropdown contents
 		if (self.isOpen) {
 			self.refreshOptions(false);


### PR DESCRIPTION
I think we should invalidate `lastQuery` on `updateOption` because we might have updated the `sortField`.

I was getting some elements out of order (elements that get it's label changed). After this fix, everything is fine.

I know this has an impact on performance (only if using `updateOption`), but the user can update all the desired options, and only then perform a `refreshOptions(false)`.
Furthermore, I think this enforces correctness.

Tests missing. :worried: 
