### PR TITLE
Mak unreachable code inside setActiveItem with shift/ctrl mousedown

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -202,7 +202,7 @@ $.extend(Selectize.prototype, {
 		$dropdown.on('mouseenter mousedown mouseup click', '[data-disabled]>[data-selectable]', function(e) { e.stopImmediatePropagation(); });
 		$dropdown.on('mouseenter', '[data-selectable]', function() { return self.onOptionHover.apply(self, arguments); });
 		$dropdown.on('mouseup click', '[data-selectable]', function() { return self.onOptionSelect.apply(self, arguments); });
-		watchChildEvent($control, 'mouseup', '*:not(input)', function() { return self.onItemSelect.apply(self, arguments); });
+		watchChildEvent($control, 'mousedown', '*:not(input)', function() { return self.onItemSelect.apply(self, arguments); });
 		autoGrow($control_input);
 
 		$control.on({
@@ -941,7 +941,7 @@ $.extend(Selectize.prototype, {
 				}
 			}
 			e.preventDefault();
-		} else if ((eventName === 'mousedown' && self.isCtrlDown) || (eventName === 'keydown' && this.isShiftDown)) {
+		} else if (eventName === 'mousedown' && self.isCtrlDown) {
 			if ($item.hasClass('active')) {
 				idx = self.$activeItems.indexOf($item[0]);
 				self.$activeItems.splice(idx, 1);


### PR DESCRIPTION
`setActiveItem` with event is called by `onItemSelect` and it is triggered by `watchChildEvent($control, 'mouseup', '*:not(input)', function() { return self.onItemSelect.apply(self, arguments); });`
So `eventName === 'mousedown'`is always false because eventName is mouseup.
Also ` (eventName === 'keydown' && this.isShiftDown)` is always flase too.