### PR TITLE
Fix: Close dropdown when clicking other selectize

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -437,6 +437,7 @@ $.extend(Selectize.prototype, {
           }
         }, 0);
 			}
+      return;
 		}
 		// retain focus by preventing native handling. if the
 		// event target is the input it should not be modified.


### PR DESCRIPTION
By '8c440b07176916c0e2ebb79e5431e7a45723c9f7 Open drop-down on mouse-click if openOnFocus is false and when clicking on the options.' !self.isFocused location changed.
As a side effect When you click other selectize input in same window, the previous selectize onBlur event not fired and focus/ dropdown remains. Fix this issue.