### PR TITLE
Fix: activating multiple item when clicking an item with ctrl/shift + click

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -446,7 +446,7 @@ $.extend(Selectize.prototype, {
 				// toggle dropdown
 				self.isOpen ? self.close() : self.open();
 			} else {
-				if (!defaultPrevented) {
+				if (!defaultPrevented && !self.isShiftDown && !self.isCmdDown) {
 						self.setActiveItem(null);
 				}
 				if (!self.settings.openOnFocus) {
@@ -924,7 +924,7 @@ $.extend(Selectize.prototype, {
 		// modify selection
 		eventName = e && e.type.toLowerCase();
 
-		if (eventName === 'mousedown' && self.isShiftDown && self.$activeItems.length) {
+		if (eventName === 'mouseup' && self.isShiftDown && self.$activeItems.length) {
 			$last = self.$control.children('.active:last');
 			begin = Array.prototype.indexOf.apply(self.$control[0].childNodes, [$last[0]]);
 			end   = Array.prototype.indexOf.apply(self.$control[0].childNodes, [$item[0]]);
@@ -941,7 +941,7 @@ $.extend(Selectize.prototype, {
 				}
 			}
 			e.preventDefault();
-		} else if ((eventName === 'mousedown' && self.isCtrlDown) || (eventName === 'keydown' && this.isShiftDown)) {
+		} else if (eventName === 'mouseup' && self.isCtrlDown) {
 			if ($item.hasClass('active')) {
 				idx = self.$activeItems.indexOf($item[0]);
 				self.$activeItems.splice(idx, 1);


### PR DESCRIPTION
https://github.com/selectize/selectize.js/pull/1813/commits/e5792126a839095e00a743a5bade38caabeac4e5#r890628729
This commit change the item activating event trigger from mousedown to mouseup. As a side effect Activating multiple item function is broke. Fix this bug.