### PR TITLE
Add index.d.ts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "url": "git://github.com/selectize/selectize.js.git"
   },
   "files": [
+    "index.d.ts",
     "dist/*"
   ],
+  "types": "index.d.ts",
   "devDependencies": {
     "@risadams/gulp-wrapper": "1.0.0",
     "@types/jquery": "^3.5.16",


### PR DESCRIPTION
Closes #2002 

This PR should not be merged without first addressing #2145. Currently the lack of a typescript definition file can be worked around by using the definition file from https://github.com/DefinitelyTyped/DefinitelyTyped, which appears to be more up-to-date (though [not completely](https://github.com/DefinitelyTyped/DefinitelyTyped/issues?q=is%3Aissue+is%3Aopen+selectize)).