### PR TITLE
Add a `removeCurrentItems` parameter to `clearOptions()` to allow for either intended behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 <!-- Feel free to put either your handle and/or full name, according to
      your privacy needs -->
 
+## v0.16.0 [In development]
+
+### Breaking changes
+
+- `clearOptions()` now, by default, removes currently-selected items in addition to deselecting them,
+  as it did prior to selectize v0.12.5.
+  - This behavior is controlled by a new parameter `removeCurrentItems`, default `true`.
+  - If `removeCurrentItems` is set `false`, the function will instead leave currently-selected items
+    available *and selected*, as was the case from selectize v0.12.5, until v0.13.1 introduced
+    [#2146](https://github.com/selectize/selectize.js/issues/2146) (which this change fixes).
+  - For consistency, `silent` also has a (backwards-compatible) default value of `false` now.
+  - Thus, the full signature is now `clearOptions(silent = false, removeCurrentItems = true)`
+
+  _@dvg-p4_
+
 ## v0.15.1 · 17 11 2022
 
 - New feature: dynamically add option groups

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1486,26 +1486,33 @@ $.extend(Selectize.prototype, {
 	},
 
 	/**
-	 * Clears all options, including all selected items
+	 * Removes all options, by default including all selected items
 	 *
-	 * @param {boolean} silent
+	 * @param {boolean} [silent = false] If truthy, no change event will be fired on the original input. No effect if removeCurrentItems is false.
+	 * @param {boolean} [removeCurrentItems = true] If truthy, deselect and remove currently-selected items.
 	 */
-	clearOptions: function(silent) {
+	clearOptions: function(silent = false, removeCurrentItems = true) {
 		var self = this;
 
 		self.loadedSearches = {};
 		self.userOptions = {};
 		self.renderCache = {};
-		var options = self.options;
-		$.each(self.options, function(key, value) {
-			if(self.items.indexOf(key) == -1) {
-				delete options[key];
-			}
-		});
-		self.options = self.sifter.items = options;
+		if (removeCurrentItems) {
+			self.options = self.sifter.items = {};
+		} else {
+			var options = self.options;
+			$.each(self.options, function(key, value) {
+				if(self.items.indexOf(key) == -1) {
+					delete options[key];
+				}
+			});
+			self.options = self.sifter.items = options;
+		}
 		self.lastQuery = null;
 		self.trigger('option_clear');
-		self.clear(silent);
+		if (removeCurrentItems) {
+			self.clear(silent);
+		}
 	},
 
 	/**


### PR DESCRIPTION
* Closes #2146 
* Closes #593 (if you call `clearOptions(false, false)`)

- `clearOptions()` now, by default, removes currently-selected items in addition to deselecting them,
  as it did prior to selectize v0.12.5.
  - This behavior is controlled by a new parameter `removeCurrentItems`, default `true`.
  - If `removeCurrentItems` is set `false`, the function will instead leave currently-selected items
    available *and selected*, as was the case from selectize v0.12.5, until v0.13.1 introduced
    [#2146](https://github.com/selectize/selectize.js/issues/2146) (which this change fixes).
  - For consistency, `silent` also has a (backwards-compatible) default value of `false` now.
  - Thus, the full signature is now `clearOptions(silent = false, removeCurrentItems = true)`

I don't feel very strongly about the new parameter being default `true`, as long as whatever its default value is, is correctly and comprehensively documented. You could make the argument either way.